### PR TITLE
Remove android:allowBackup="false" from library manifest

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="pl.tajchert.waitingdots">
 
-    <application android:allowBackup="true" android:label="@string/app_name">
+    <application android:label="@string/app_name">
 
     </application>
 


### PR DESCRIPTION
Currently I get a manifest merging error because my app sets android:allowBackup="false" and this conflicts.

Library projects shouldn't be setting this.
