### PR TITLE
Workaround for view not being drawn Lollipop and higher

### DIFF
--- a/lib/src/main/java/pl/tajchert/sample/DotsTextView.java
+++ b/lib/src/main/java/pl/tajchert/sample/DotsTextView.java
@@ -69,7 +69,7 @@ public class DotsTextView extends TextView {
         dotTwo = new JumpingSpan();
         dotThree = new JumpingSpan();
 
-        SpannableString spannable = new SpannableString("...");
+        SpannableString spannable = new SpannableString("...\u200B");
         spannable.setSpan(dotOne, 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         spannable.setSpan(dotTwo, 1, 2, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         spannable.setSpan(dotThree, 2, 3, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);

--- a/lib/src/main/java/pl/tajchert/sample/DotsTextView.java
+++ b/lib/src/main/java/pl/tajchert/sample/DotsTextView.java
@@ -89,7 +89,7 @@ public class DotsTextView extends TextView {
                 period / 6), createDotJumpAnimator(dotThree, period * 2 / 6));
 
         isPlaying = autoPlay;
-        if(autoPlay) {
+        if (autoPlay && !isInEditMode()) {
             start();
         }
     }


### PR DESCRIPTION
Fixes #7 

If the SpannableString consists solely of spans, the spans aren't being drawn, or something like that. Adding an Zero Width Space (\u200B) works around this.

References:
- http://stackoverflow.com/questions/26399111/android-edittext-how-to-create-an-empty-bullet-paragraph-by-bulletspan
- http://stackoverflow.com/questions/20069537/replacementspans-draw-method-isnt-called
